### PR TITLE
Use assert_cmd to execute rpick in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
+      # Test with the release flag before we have a debug build. This ensures that
+      # https://github.com/bowlofeggs/rpick/issues/20 doesn't happen again.
+      - name: Run cargo test --release
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1679af9a1ab4bea16f228b05d18f8363f8327b1fa8db00d2760cfafc6b61e"
+dependencies = [
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +217,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -369,6 +394,32 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
+dependencies = [
+ "difference",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3dbeaaf793584e29c58c7e3a82bbb3c7c06b63cea68d13b0e3cddc124104dc"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee95d988ee893cb35c06b148c80ed2cd52c8eea927f50ba7a0be1a786aeab73"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -598,6 +649,7 @@ dependencies = [
 name = "rpick"
 version = "0.7.1"
 dependencies = [
+ "assert_cmd",
  "dirs 3.0.1",
  "prettytable-rs",
  "rand 0.8.2",
@@ -756,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +848,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ structopt = "0.3"
 term = "0.5"
 
 [dev-dependencies]
+assert_cmd = "1"
 rand = {version = "0.8", features = ["small_rng"]}
 regex = "1"
 tempfile = "3"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check audit build clean clippy doc fmt test
+.PHONY: help check audit build clean clippy doc fmt test test_release
 
 # Where the project is mounted inside the container
 podman_mount_dir = /rpick
@@ -12,7 +12,7 @@ podman_run = podman run --network=host --rm -it $(podman_volume) -e RPICK_CONFIG
 help:  ## Show this help
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-check: fmt audit build clippy test doc  ## Run the full set of CI checks
+check: fmt audit test_release build clippy test doc  ## Run the full set of CI checks
 
 audit: container  ## Run cargo audit
 	$(podman_run) cargo audit
@@ -46,3 +46,6 @@ shell: container  ## Run bash inside the development container
 
 test: container  ## Run cargo test
 	$(podman_run) cargo test
+
+test_release: container  # Run cargo test --release
+	$(podman_run) cargo test --release


### PR DESCRIPTION
Prior to this commit, rpick's integration tests had hardcoded to
test a debug build. This worked fine for development and CI, but
did not work when tests were exeucted with cargo test --release.

The tests were refactored to use assert_cmd instead, which has a
facility to discover the correct executable to test. It also
turned out to have a more convenient API for testing a CLI than
using std::process::Command does.

fixes #20
re https://github.com/gentoo/gentoo/pull/19073
re https://bugs.gentoo.org/765604

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>