### PR TITLE
Introduce a new UI trait and alter API to use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.8.0
+
+This is a backwards breaking change in the crate.
+
+* Redesigned the Engine API. It now requires an instance of a struct that implements the
+  rpick::ui::UI trait. This trait provides a more natural way to interact with the library than
+  streams of bytes.
+
 # 0.7.2
 
 * [#19](https://github.com/bowlofeggs/rpick/issues/19) Update rand to 0.8.2.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
 dependencies = [
- "approx",
+ "approx 0.3.2",
  "num-complex",
  "num-traits",
 ]
@@ -34,6 +34,15 @@ name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
  "num-traits",
 ]
@@ -227,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+
+[[package]]
 name = "dtoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +252,21 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "generic-array"
@@ -260,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -280,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -333,13 +363,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "mockall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619634fd9149c4a06e66d8fd9256e85326d8eeee75abee4565ff76c92e4edfe0"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83714c95dbf4c24202f0f1b208f0f248e6bd65abfa8989303611a71c0f781548"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0abb021006c01b126a936a8dd1351e0720d83995f4fc942d0d426c654f990745"
 dependencies = [
  "alga",
- "approx",
+ "approx 0.3.2",
  "generic-array",
  "matrixmultiply",
  "num-complex",
@@ -349,6 +406,12 @@ dependencies = [
  "rand_distr 0.2.2",
  "typenum",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-complex"
@@ -392,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,7 +473,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
 dependencies = [
  "difference",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -539,7 +611,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom 0.2.1",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -617,7 +689,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.1",
+ "getrandom 0.2.2",
  "redox_syscall 0.2.4",
 ]
 
@@ -659,10 +731,12 @@ dependencies = [
 
 [[package]]
 name = "rpick"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
+ "approx 0.4.0",
  "assert_cmd",
  "dirs-next",
+ "mockall",
  "prettytable-rs",
  "rand 0.8.3",
  "rand_distr 0.4.0",
@@ -672,7 +746,6 @@ dependencies = [
  "statrs",
  "structopt",
  "tempfile",
- "term",
 ]
 
 [[package]]
@@ -812,11 +885,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpick"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Randy Barlow <randy@electronsweatshop.com>"]
 license = "GPL-3.0"
 readme = "README.md"
@@ -22,10 +22,11 @@ serde = {version = "1.0", features = ["derive"]}
 serde_yaml = "0.8"
 statrs = "0.13"
 structopt = "0.3"
-term = "0.5"
 
 [dev-dependencies]
+approx = "0.4"
 assert_cmd = "1"
+mockall = "0.9"
 rand = {version = "0.8", features = ["small_rng"]}
 regex = "1"
 tempfile = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,100 @@
+/* Copyright © 2021 Randy Barlow
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
+//! Define the code that drives the rpick CLI UI.
+
+use std::io::{self, BufRead, Write};
+
+use prettytable::{format, Cell, Row, Table};
+
+use rpick::ui;
+
+/// This implements the UI trait for the rpick engine.
+pub struct CLI {
+    /// If true, print out the chance tables.
+    verbose: bool,
+}
+
+impl CLI {
+    /// Construct a new CLI.
+    ///
+    /// # Arguments
+    ///
+    /// * `verbose`: If true, the CLI will print out chance tables.
+    pub fn new(verbose: bool) -> Self {
+        CLI { verbose }
+    }
+
+    /// Convert a slice of Cells into a [`prettytable::Row`].
+    ///
+    /// # Arguments
+    ///
+    /// * `row`: The slice of Cells to convert.
+    /// * `highlight`: If true, this row will get emphasized on terminals that support colors.
+    fn convert_row(row: &[ui::Cell], highlight: bool) -> Row {
+        let mut r = Row::empty();
+
+        for c in row {
+            let mut c = if let ui::Cell::Float(value) = c {
+                Cell::new(&format!("{:>6.2}%", value))
+            } else {
+                Cell::new(&String::from(c))
+            };
+            if highlight {
+                c = c.style_spec("bFy");
+            }
+            r.add_cell(c);
+        }
+
+        r
+    }
+}
+
+impl ui::UI for CLI {
+    /// Return `self.verbose`.
+    fn call_display_table(&self) -> bool {
+        self.verbose
+    }
+
+    /// Print the given table to the terminal.
+    fn display_table(&self, table: &ui::Table) {
+        let mut t = Table::new();
+        t.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+
+        t.set_titles(CLI::convert_row(&table.header, false));
+
+        for row in &table.rows {
+            t.add_row(CLI::convert_row(&row.cells, row.chosen));
+        }
+        t.add_row(CLI::convert_row(&table.footer, false));
+
+        println!();
+        t.printstd();
+        println!();
+    }
+
+    /// Print the given message to the terminal.
+    fn info(&self, message: &str) {
+        println!("{}", message);
+    }
+
+    /// Ask the user if they accept the given choice and return their answer.
+    fn prompt_choice(&self, choice: &str) -> bool {
+        print!("Choice is {}. Accept? (Y/n) ", choice);
+        io::stdout().flush().unwrap();
+        let line = io::stdin().lock().lines().next().unwrap().unwrap();
+        if ["", "y", "Y"].contains(&line.as_str()) {
+            return true;
+        }
+        false
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,15 +14,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
 //!
 //! ```rpick``` helps pick items from a list of choices, using various algorithms.
 
-use std::io;
-
 use structopt::StructOpt;
-use term::Terminal;
+
+mod cli;
 
 const CONFIG_FILE: &str = "rpick.yml";
 
 #[derive(StructOpt)]
-struct Cli {
+struct CliArgs {
     /// The category you wish to pick from.
     category: String,
     #[structopt(short, long, env = "RPICK_CONFIG")]
@@ -34,25 +33,15 @@ struct Cli {
 }
 
 fn main() {
-    let args = Cli::from_args();
+    let args = CliArgs::from_args();
     let config_path = get_config_file_path(&args);
     let config = rpick::read_config(&config_path);
     match config {
         Ok(config) => {
             let mut config = config;
-            let stdio = io::stdin();
-            let input = stdio.lock();
-            let mut output = io::stdout();
-            let color = match term::terminfo::TerminfoTerminal::new(&mut output) {
-                Some(term) => term.supports_color(),
-                None => false,
-            };
+            let ui = cli::CLI::new(args.verbose);
 
-            let mut engine = rpick::Engine::new(input, output, rand::thread_rng());
-            engine.color = color;
-            if args.verbose {
-                engine.verbose = true;
-            }
+            let mut engine = rpick::Engine::new(&ui);
             match engine.pick(&mut config, args.category) {
                 Ok(_) => match rpick::write_config(&config_path, config) {
                     Ok(_) => {}
@@ -78,7 +67,7 @@ fn main() {
 ///
 /// If the config flag is set in the given CLI args, that path is used. Otherwise, the default
 /// config name (CONFIG_FILE) is appended to the user's home config directory to form the path.
-fn get_config_file_path(args: &Cli) -> String {
+fn get_config_file_path(args: &CliArgs) -> String {
     match &args.config {
         Some(config) => config.clone(),
         None => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,105 @@
+/* Copyright © 2021 Randy Barlow
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
+//! # The UI Trait
+//!
+//! The UI Trait defines an interface for bridging human interactions with the rpick crate.
+
+#[cfg(test)]
+use mockall::automock;
+
+/// An individual cell within rpick's chance tables.
+///
+/// Each of the variants expresses its contained type, and should be fairly obvious.
+#[non_exhaustive]
+#[derive(Debug, PartialEq)]
+pub enum Cell<'a> {
+    Boolean(bool),
+    Text(&'a str),
+    Integer(i64),
+    Float(f64),
+    Unsigned(u64),
+}
+
+impl<'a> From<f64> for Cell<'_> {
+    fn from(f: f64) -> Self {
+        Self::Float(f)
+    }
+}
+
+impl<'a> From<&'a str> for Cell<'a> {
+    fn from(s: &'a str) -> Self {
+        Self::Text(s)
+    }
+}
+
+impl<'a> From<u64> for Cell<'_> {
+    fn from(u: u64) -> Self {
+        Self::Unsigned(u)
+    }
+}
+
+impl<'a> From<&Cell<'_>> for String {
+    fn from(c: &Cell) -> String {
+        match c {
+            Cell::Boolean(value) => value.to_string(),
+            Cell::Text(value) => value.to_string(),
+            Cell::Integer(value) => value.to_string(),
+            Cell::Float(value) => value.to_string(),
+            Cell::Unsigned(value) => value.to_string(),
+        }
+    }
+}
+
+/// Represents a row in the [`Table`] struct.
+#[derive(Debug, PartialEq)]
+pub struct Row<'a> {
+    /// The row's individual cells.
+    pub cells: Vec<Cell<'a>>,
+    /// Whether this row was chosen in a rpick.
+    pub chosen: bool,
+}
+
+/// rpick uses this to send a chance table to the user.
+#[derive(Debug, PartialEq)]
+pub struct Table<'a> {
+    /// The Table's footer.
+    pub footer: Vec<Cell<'a>>,
+    /// The Table's header.
+    pub header: Vec<Cell<'a>>,
+    /// The Table's rows.
+    pub rows: Vec<Row<'a>>,
+}
+
+/// A struct implementing this trait must be passed to the rpick engine.
+///
+/// This is how rpick interacts with users.
+#[cfg_attr(test, automock)]
+pub trait UI {
+    /// If this method returns `true`, [`UI::display_table`] will be called by the engine.
+    ///
+    /// This is a small optimization - generating tables that the UI isn't going to show to the
+    /// user or otherwise use is a waste of compute time. If the table isn't going to get used,
+    /// this method should return `false`.
+    fn call_display_table(&self) -> bool;
+
+    /// Display the given table to the user.
+    fn display_table<'a>(&self, table: &Table<'a>);
+
+    /// Display the given message to the user.
+    fn info(&self, message: &str);
+
+    /// Prompt the user if they wish to accept the given choice.
+    ///
+    /// Return `true` if the user accepts the choice.
+    fn prompt_choice(&self, choice: &str) -> bool;
+}


### PR DESCRIPTION
This is a backwards breaking change in the crate.

The Engine now receives only an instance of a struct that
implements the new UI trait. The UI trait is friendlier towards API
users than streams of text.

Instantiating an Engine no longer accepts an Rng. There is a new
set_rng() method on the Engine if you wish to provide your own
Rng.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>