### PR TITLE
Revert "No longer publish to the deschamps registry"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,3 +81,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: publish
+      - name: Configure Cargo registry for deschamps
+        run: |
+          echo -e '[registries.deschamps]\nindex = "https://git.deschamps.network/crates/index.git"' >> ~/.cargo/config
+      - name: Publish to deschamps
+        env:
+          CARGO_REGISTRIES_DESCHAMPS_TOKEN: ${{ secrets.DESCHAMPS_CARGO_REGISTRY_TOKEN }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --registry deschamps


### PR DESCRIPTION
This reverts commit 542c246f4aeea744abf30db3c79f4d0b1afe3a8d.

I always told you I strive for nine fives of uptime. Sure, it took me
from July to September to get around to running `pg_update`. Yes, it
only took a few minutes and I could have done it a long time ago. But
I think I'm still sitting around 70% uptime, so I think you should give
me another chance.
