### PR TITLE
Configure dependabot grouped updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+groups:
+  dependencies:
+    patterns: ["*"]


### PR DESCRIPTION
This feature was just recently released:
https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/

Now you'll have fewer PRs to ignore!
