### PR TITLE
meta: migrate away from deprecated SPDX license identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rpick"
 version = "0.9.1"
 authors = ["Randy Barlow <randy@electronsweatshop.com>"]
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 readme = "README.md"
 repository = "https://github.com/bowlofeggs/rpick"
 documentation = "https://docs.rs/rpick"


### PR DESCRIPTION
The "GPL-3.0" identifier has been deprecated since version 3.0 of the SPDX license list: https://spdx.org/licenses/#deprecated

This PR was created under the assumption that `GPL-3.0` was meant to convey `GPL-3.0-only` (and not `GPL-3.0-or-later`, which would have been equivalent to the `GPL-3.0+` identifier).