### PR TITLE
Bump actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v2
       - name: Cache compilation assets
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: build-${{ matrix.rust_version.version }}-${{ matrix.build_type.name }}
         with:
@@ -64,7 +64,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v2
       - name: Cache compilation assets
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: clippy
         with:
@@ -85,7 +85,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v2
       - name: Cache compilation assets
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: doc
         with:
@@ -129,7 +129,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v2
       - name: Cache compilation assets
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: test-${{ matrix.rust_version.version }}-${{ matrix.build_type.name }}
         with:


### PR DESCRIPTION
v2 is deprecated: https://github.com/actions/cache/discussions/1510